### PR TITLE
Don't hide when a test fails

### DIFF
--- a/logger/src/main/scala/jetbrains/buildServer/SbtTeamCityLogger.scala
+++ b/logger/src/main/scala/jetbrains/buildServer/SbtTeamCityLogger.scala
@@ -73,33 +73,7 @@ object SbtTeamCityLogger extends Plugin with (State => State) {
     System.setProperty(TC_LOGGER_PROPERTY_NAME, "reloaded")
   }
 
-  var testResultLoggerFound = true
-
-  try {
-    val trl: Def.Initialize[sbt.TestResultLogger] = Def.setting {
-      (testResultLogger in Test).value
-    }
-  } catch {
-    case nsm: java.lang.NoSuchMethodError => {
-      testResultLoggerFound = false
-    }
-  }
-
-  override lazy val projectSettings = if (tcFound && testResultLoggerFound)
-    (loggerOnSettings ++ Seq(
-      testResultLogger in(Test, test) := new TestResultLogger {
-
-        import sbt.Tests._
-
-        def run(log: Logger, results: Output, taskName: String): Unit = {
-          //default behaviour there is
-          //TestResultLogger.SilentWhenNoTests.run(log, results, taskName)
-          //we will just ignore to prevent appearing of 'exit code 1' when test failed
-        }
-      }
-    )
-      )
-  else if (tcFound) loggerOnSettings
+  override lazy val projectSettings = if (tcFound) loggerOnSettings
   else loggerOffSettings
 
 


### PR DESCRIPTION
This is an attempt to solve the issue of a non-blocking failing test.

We (the Guardian) have encountered issues when using the embedded version of sbt. The observed behaviour is that in the case of a test failure the build process continues and produce an artefact. The expected behaviour would be to stop on test failure.

This has been documented at least [here](https://youtrack.jetbrains.com/issue/TW-50753), [here](https://github.com/JetBrains/sbt-tc-logger/issues/12) and [here](https://github.com/JetBrains/sbt-tc-logger/issues/9).

I have found [that ticket](https://youtrack.jetbrains.com/issue/TW-40904#u=1430320006815) describing what were these lines supposed to do in the first place, but the ticket doesn't explain why it should.

Since I can't find a good justification, and given the potential production issues the current version can cause, I am rising the current PR in the hope it will be merged and released.

I successfully tested the change using @jsancio 's [repo](https://github.com/jsancio/teamcity-test) but didn't push the change to teamcity to test it _in situ_ as it's not the most obvious set-up to make.

Please let me know if I missed anything obvious and if there's a good reason to hide "Process exited with code 1" as I don't know teamcity very well.

Thanks for your help